### PR TITLE
Fix import paths for older versions of QIGS/Processing

### DIFF
--- a/ClipToHemisphere.py
+++ b/ClipToHemisphere.py
@@ -31,8 +31,13 @@ import PyQt4.QtCore
 from processing.core.Processing import Processing
 from processing.core.AlgorithmProvider import AlgorithmProvider
 from processing.core.GeoAlgorithm import GeoAlgorithm
-from processing.core.parameters import ParameterVector, ParameterNumber
-from processing.core.outputs import OutputVector
+try:
+    from processing.parameters.ParameterVector import ParameterVector
+    from processing.parameters.ParameterNumber import ParameterNumber
+    from processing.outputs.OutputVector import OutputVector
+except ImportError:
+    from processing.core.parameters import ParameterVector, ParameterNumber
+    from processing.core.outputs import OutputVector
 from processing.core.ProcessingConfig import Setting, ProcessingConfig
 from processing.tools import dataobjects, vector
 


### PR DESCRIPTION
For my version of processing there were import errors, as described in this thread:

http://lists.osgeo.org/pipermail/qgis-developer/2014-July/033995.html

Upgrading my version of processing to match my QGIS version will likely fix the problem, but this PR includes a fix to make it work in older versions. Tested and it works as expected.
